### PR TITLE
Allowing using extension different than engine's shortname

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function render(path, engine, opts) {
   opts = opts || {};
 
   return function *(next) {
-    opts.ext = engine;
+    if (opts.ext == null) opts.ext = engine;
     this.render = views(path, opts);
 
     yield next;


### PR DESCRIPTION
Handling the case where you want to specify a default extension which is not the name of the engine.

Issue:

```
app.use(views('./views','underscore');
```

forces you to have template named `./views/name.underscore`

I would love to be able to do something like this

```
app.use(views('./views','underscore',{ext:"html", map: { html: 'underscore' } }));
```

but the extension gets overwritten.

Let me know if I'm missing something.
