### PR TITLE
Honor upstream middlewares that may have already set this.locals

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,10 +45,11 @@ module.exports = function (path, opts) {
     if (this.locals && this.render) return;
 
     /**
-     * App-specific `locals`.
+     * App-specific `locals`, but honor upstream
+     * middlewares that may have already set this.locals.
      */
 
-    this.locals = {}
+    this.locals = this.locals || {};
 
     /**
      * Render `view` with `locals`.


### PR DESCRIPTION
Because `Koajs` creates a new context (`this`) on each request, we can safely allow upstream middlewares to create and populate a `this.locals` object to be used in `koa-views`.

Currently, `koa-views` kills and replaces any upstream `this.locals`.
