### PR TITLE
Need to set Content-Type

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,6 +71,7 @@ module.exports = function (path, opts) {
         var ext = opts.default;
         debug(fmt('render `%s.%s` with %j', view, ext, locals));
         this.body = yield render(view, locals);
+        this.type = 'text/html';
       }
     }
 


### PR DESCRIPTION
If the response has gone through multiple middlewares, which may change
the response's `Content-Type`, this middleware should reset it to HTML.
