### PR TITLE
update this.render to generator function

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,6 @@ module.exports = function (path, opts) {
      *
      * @param {String} view
      * @param {Object} locals
-     * @return {GeneratorFunction}
      * @api public
      */
 


### PR DESCRIPTION
in some situation, when Anonymous generator function are returned, the `this` in the function are refered to `global` insteadof the koa ctx.
Thus the `this.body=` will set `global.body`, and this.body will be undefined in follow middlewares.
So, insteadof returning the function, make this.render just a generator function can solve the problem.
