### PR TITLE
print options object when 'debug' mode used

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = function (path, opts) {
   // default extension to `html`
   if (!opts.default) opts.default = 'html';
 
-  debug(fmt('options: %s', opts));
+  debug(fmt('options: ', opts));
 
   return function *views (next) {
     if (this.render) return yield next;


### PR DESCRIPTION
in debug mode currently this is shown:
koa-views options: [object Object]

this is because util.format is used with %s option while object is passed
either we can remove the %s specifier (as in this pull request) or use JSON.stringify() on options object