### PR TITLE
Update readme doc to avoid confusion.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ $ npm install koa-views
 // Must be used before any router is used
 app.use(views('views', {
   map: {
-    html: underscore
+    html: 'underscore'
   }
 }));
 


### PR DESCRIPTION
Lost quite a bit of time trying to figure out what was wrong with my code. Specifying which template engine to use using the existing example in ```Readme.md``` kept giving me errors: 
 
```
   // Must be used before any router is used
   app.use(views('views', {
      map: {
        html: underscore
     }
   }));
```

Finally changing this around to below worked for me. If this is the case then i think the example should be updated in ```Readme.md```

```
   // Must be used before any router is used
   app.use(views('views', {
      map: {
        html: 'underscore' //specify template engine using a string
     }
   }));
```