### PR TITLE
fix #82, extension should not be changed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,22 +19,22 @@ function viewsMiddleware (path, {
     if (ctx.render) return next()
 
     ctx.render = function (relPath, locals = {}) {
-      extension = (extname(relPath) || '.' + extension).slice(1)
+      const suffix = (extname(relPath) || '.' + extension).slice(1)
 
-      return getPaths(path, relPath, extension)
+      return getPaths(path, relPath, suffix)
         .then((paths) => {
           const state = Object.assign(locals, options, ctx.state || {})
           debug('render `%s` with %j', paths.rel, state)
           ctx.type = 'text/html'
 
-          if (isHtml(extension) && !map) {
+          if (isHtml(suffix) && !map) {
             return send(ctx, paths.rel, {
               root: path
             })
           } else {
-            const engineName = map && map[extension]
-              ? map[extension]
-              : extension
+            const engineName = map && map[suffix]
+              ? map[suffix]
+              : suffix
 
             const render = engineSource[engineName]
 

--- a/test/index.js
+++ b/test/index.js
@@ -194,4 +194,38 @@ describe('koa-views', function () {
         .expect(/hello/)
         .expect(200, done)
   })
+
+  // #82
+  describe('extension is ejs, frist visit basic.html then visit basic should render basic.ejs', function () {
+    const app = new Koa()
+        .use(views(__dirname + '/fixtures', {
+          extension: 'ejs'
+        }))
+        .use(function (ctx, next) {
+          if("/html" === ctx.path){
+            return ctx.render("basic.html")
+          }
+          return next()
+        })
+        .use(function (ctx, next) {
+          if("/ejs" === ctx.path){
+            return ctx.render("basic")
+          }
+          return next()
+        })
+
+    const server = request(app.listen())
+
+    it('first visit html', function (done){
+      server.get('/html')
+        .expect(/basic:html/)
+        .expect(200, done)
+    })
+
+    it('then visit ejs should render basic basic.ejs', function (done){
+      server.get('/ejs')
+        .expect(/basic:ejs/)
+        .expect(200, done)
+    })
+  })
 })


### PR DESCRIPTION
I set `options.extension` to `ejs`.
when I use `ctx.render('index.html')` will change `options.extension = 'html'`.

```javascript
extension = (extname(relPath) || '.' + extension).slice(1) // extension should not be changed
```

which is wrong

see [#82](https://github.com/queckezz/koa-views/issues/82)