### PR TITLE
make partials in handlebars work regular (#77)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,10 @@ function viewsMiddleware (path, {
       return getPaths(path, relPath, extension)
         .then((paths) => {
           const state = Object.assign(locals, options, ctx.state || {})
+          state.partials={};
+          for(var i in options.partials){
+            state.partials[i]=options.partials[i]
+          }
           debug('render `%s` with %j', paths.rel, state)
           ctx.type = 'text/html'
 


### PR DESCRIPTION
copy `options.partials` to `state.partials`  
to avoid partials object be modified ,which make hbs partials render error
after code
`var state = Object.assign(locals, options, ctx.state || {})`
