### PR TITLE
Set Consolidate options.settings.views property by default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,9 @@ function viewsMiddleware (path, {
               root: path
             })
           } else {
+            if (!options.hasOwnProperty('nunjucksEnv')) {
+              state.settings = { views: path }
+            }
             const engineName = map && map[suffix]
               ? map[suffix]
               : suffix


### PR DESCRIPTION
The search path for the directory containing template files for most of the engines supported by Consolidate is configured by setting the `options.settings.views`  for the options parameter in:
```javascript
consolidate.engineName.render(string, options)
```
If you take a look at the source for [consolidate.js](https://github.com/tj/consolidate.js/blob/master/lib/consolidate.js) in the Consolidate project, you will see numerous references to `options.settings.views`

In the case of invoking  koa-views with the typical  options of:
```javascript
app.use(views(__dirname, { map: {html: 'nunjucks' }}))
```
If you inspect [index.js line #46 ](https://github.com/queckezz/koa-views/blob/master/src/index.js#L46)  you will see that the Nunjucks FileSystemLoader constructor is called with undefined parameters `nunjucks.FileSystemLoader(undefined, undefined)` by Consolidate [consolidate.js line #1167](https://github.com/tj/consolidate.js/blob/master/lib/consolidate.js#L1167) for every call to koa-views' ctx#render in down stream middleware.

When the Nunjucks FileSystemLoader constructor is invoked with an undefined argument for the [template folder path](https://mozilla.github.io/nunjucks/api.html#filesystemloader), it falls back on `process.cwd` in order to determine the template file search path. Since the process.cwd can be literally ANYWHERE on the system, extending parent templates doesn't work unless you give the path relative to the node process.cwd in every extends directive. I don't know about everyone else, but I don't' want my template directives looking like: 
 ```{% extends "have/to/change/this/everytime/i/run/node/from/a/differnt/direcory.html" %}```

I didn't create any tests for this PR since I wasn't in the mood for mocking Consolidate and doing funky stuff like changing the node process working directory in order to reproduce this issue in tests. It will have to suffice that this PR solves the issue and passes the existing test suite.