### PR TITLE
Make render available on ctx.response

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ function viewsMiddleware(
   return function views(ctx, next) {
     if (ctx.render) return next()
 
-    ctx.render = function(relPath, locals = {}) {
+    ctx.response.render = ctx.render = function(relPath, locals = {}) {
       return getPaths(path, relPath, extension).then(paths => {
         const suffix = paths.ext
         const state = Object.assign(locals, options, ctx.state || {})

--- a/test/index.js
+++ b/test/index.js
@@ -9,6 +9,7 @@ describe('koa-views', () => {
     const app = new Koa().use(views()).use(ctx => {
       should(ctx.render).be.ok()
       should(ctx.render).be.a.Function()
+      should(ctx.response.render).be.equal(ctx.render)
     })
 
     request(app.listen())


### PR DESCRIPTION
Allow cleaner usage with koa:
```
exports.foo = async ({ request, response }, next) => {
    await response.render('foo/bar');
};
```