### PR TITLE
Add include engines note

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,8 @@ npm install koa-views
 
 [List of supported engines](https://github.com/tj/consolidate.js#supported-template-engines)
 
+**NOTE**: you must still install the engines you wish to use, add them to your package.json dependencies.
+
 ## Example
 
 ```js


### PR DESCRIPTION
Added the "include" engines note from the consolidate.js README.

Why?

- Because the engine(s) should be explicitely  included  into the package.json for certain packaging scenarios (notably when creating a function bundle for AWS Lambda).

- Because not everyone will automatically check the README page of consolidate / waste time.