### PR TITLE
add autoRender option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,27 @@ app.use(render('home', { title : 'Home Page' }));
 
 * `root`: Where your views are located. Must be an absolute path. All rendered views are relative to this path
 * `opts` (optional)
+
+* `opts.autoRender`: Whether to use `ctx.body` to receive the rendered template string. Defaults to `true`.
+
+```js
+app.use(views(__dirname, { autoRender: false, extension: 'pug' }))
+
+app.use(async function (ctx) {
+  return await ctx.render('user.pug')
+})
+```
+
+vs.
+
+```js
+app.use(views(__dirname, { extension: 'pug' }))
+
+app.use(async function (ctx) {
+  await ctx.render('user.pug')
+})
+```
+
 * `opts.extension`: Default extension for your views
 
 Instead of providing the full file extension you can omit it.

--- a/src/index.js
+++ b/src/index.js
@@ -49,8 +49,7 @@ function viewsMiddleware(
 
             if (autoRender) {
               ctx.body = html
-            }
-            else {
+            } else {
               return Promise.resolve(html)
             }
           })

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ module.exports = viewsMiddleware
 
 function viewsMiddleware(
   path,
-  { engineSource = consolidate, extension = 'html', options = {}, map } = {}
+  { autoRender = true, engineSource = consolidate, extension = 'html', options = {}, map } = {}
 ) {
   return function views(ctx, next) {
     if (ctx.render) return next()
@@ -46,7 +46,13 @@ function viewsMiddleware(
               debug('using `pretty` package to beautify HTML')
               html = pretty(html)
             }
-            ctx.body = html
+
+            if (autoRender) {
+              ctx.body = html
+            }
+            else {
+              return Promise.resolve(html)
+            }
           })
         }
       })

--- a/test/index.js
+++ b/test/index.js
@@ -29,6 +29,19 @@ describe('koa-views', () => {
       .expect(200, done)
   })
 
+  it('autoRender is false', done => {
+    const app = new Koa().use(views(__dirname, { autoRender: false, extension: 'ejs' })).use(async (ctx) => {
+      let res = await ctx.render('./fixtures/basic')
+      ctx.body = res
+    })
+
+    request(app.listen())
+      .get('/')
+      .expect('Content-Type', /html/)
+      .expect(/basic:ejs/)
+      .expect(200, done)
+  })
+
   it('default to [ext] if a default engine is set', done => {
     const app = new Koa()
       .use(views(__dirname, {extension: 'pug'}))


### PR DESCRIPTION
In some cases, we will wanna use `return await ctx.render()`. So I add an extra option to resolve it.