### PR TITLE
fix: mustache support

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "precommit": "lint, test",
   "dependencies": {
-    "consolidate": "0.15.1",
+    "consolidate": "^0.16.0",
     "debug": "^4.1.0",
     "get-paths": "0.0.7",
     "koa-send": "^5.0.0",


### PR DESCRIPTION
**Error**: When i use the [mustache](https://github.com/janl/mustache.js/) template engine, i got an error: `engine.to_html is not a function`.

**Why**: The [mustache](https://github.com/janl/mustache.js/) removed the `to_html` method in v4 (https://github.com/janl/mustache.js/pull/735).

**Resolution**: Upgrade to v0.16.0, the [consolidate.js](https://github.com/tj/consolidate.js) fixed it in v0.16.0 (https://github.com/tj/consolidate.js/pull/332).