### PR TITLE
fix: specify types as optional peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-views",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -71,14 +71,6 @@
         }
       }
     },
-    "@types/accepts": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
-      "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/babel-types": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.9.tgz",
@@ -94,132 +86,11 @@
         "@types/babel-types": "*"
       }
     },
-    "@types/body-parser": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
-      "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
-      "requires": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/connect": {
-      "version": "3.4.34",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.34.tgz",
-      "integrity": "sha512-ePPA/JuI+X0vb+gSWlPKOY0NdNAie/rPUqX2GUPpbZwiKTkSPhjXWuee47E4MtE54QVzGCQMQkAL6JhV2E1+cQ==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/content-disposition": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.3.tgz",
-      "integrity": "sha512-P1bffQfhD3O4LW0ioENXUhZ9OIa0Zn+P7M+pWgkCKaT53wVLSq0mrKksCID/FGHpFhRSxRGhgrQmfhRuzwtKdg=="
-    },
-    "@types/cookies": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.6.tgz",
-      "integrity": "sha512-FK4U5Qyn7/Sc5ih233OuHO0qAkOpEcD/eG6584yEiLKizTFRny86qHLe/rej3HFQrkBuUjF4whFliAdODbVN/w==",
-      "requires": {
-        "@types/connect": "*",
-        "@types/express": "*",
-        "@types/keygrip": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/express": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.11.tgz",
-      "integrity": "sha512-no+R6rW60JEc59977wIxreQVsIEOAYwgCqldrA/vkpCnbD7MqTefO97lmoBe4WE0F156bC4uLSP1XHDOySnChg==",
-      "requires": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.18",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "@types/express-serve-static-core": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.19.tgz",
-      "integrity": "sha512-DJOSHzX7pCiSElWaGR8kCprwibCB/3yW6vcT8VG3P0SJjnv19gnWG/AZMfM60Xj/YJIp/YCaDHyvzsFVeniARA==",
-      "requires": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*"
-      }
-    },
-    "@types/http-assert": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.1.tgz",
-      "integrity": "sha512-PGAK759pxyfXE78NbKxyfRcWYA/KwW17X290cNev/qAsn9eQIxkH4shoNBafH37wewhDG/0p1cHPbK6+SzZjWQ=="
-    },
-    "@types/http-errors": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.0.tgz",
-      "integrity": "sha512-2aoSC4UUbHDj2uCsCxcG/vRMXey/m17bC7UwitVm5hn22nI8O8Y9iDpA76Orc+DWkQ4zZrOKEshCqR/jSuXAHA=="
-    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
-    },
-    "@types/keygrip": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
-      "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw=="
-    },
-    "@types/koa": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.1.tgz",
-      "integrity": "sha512-Qbno7FWom9nNqu0yHZ6A0+RWt4mrYBhw3wpBAQ3+IuzGcLlfeYkzZrnMq5wsxulN2np8M4KKeUpTodsOsSad5Q==",
-      "requires": {
-        "@types/accepts": "*",
-        "@types/content-disposition": "*",
-        "@types/cookies": "*",
-        "@types/http-assert": "*",
-        "@types/http-errors": "*",
-        "@types/keygrip": "*",
-        "@types/koa-compose": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/koa-compose": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.5.tgz",
-      "integrity": "sha512-B8nG/OoE1ORZqCkBVsup/AKcvjdgoHnfi4pZMn5UwAPCbhk/96xyv284eBYW8JlQbQ7zDmnpFr68I/40mFoIBQ==",
-      "requires": {
-        "@types/koa": "*"
-      }
-    },
-    "@types/mime": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
-      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
-    },
-    "@types/node": {
-      "version": "14.14.35",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
-      "integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag=="
-    },
-    "@types/qs": {
-      "version": "6.9.6",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.6.tgz",
-      "integrity": "sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA=="
-    },
-    "@types/range-parser": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
-      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
-    },
-    "@types/serve-static": {
-      "version": "1.13.9",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.9.tgz",
-      "integrity": "sha512-ZFqF6qa48XsPdjXV5Gsz0Zqmux2PerNd3a/ktL45mHpa19cuMi/cL8tcxdAx497yRh+QtYPuofjT9oWw9P7nkA==",
-      "requires": {
-        "@types/mime": "^1",
-        "@types/node": "*"
-      }
     },
     "a-sync-waterfall": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "precommit": "lint, test",
   "dependencies": {
-    "@types/koa": "^2.13.1",
     "consolidate": "^0.16.0",
     "debug": "^4.1.0",
     "get-paths": "0.0.7",
@@ -40,6 +39,14 @@
     "tape": "^4.4.0",
     "underscore": "^1.8.3",
     "xyz": "^2.1.0"
+  },
+  "peerDependencies": {
+    "@types/koa": "^2.13.1"
+  },
+  "peerDependenciesMeta": {
+    "@types/koa": {
+      "optional": true
+    }
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`@types` packages are only required for type-checking with TypeScript, so they shouldn't be included as direct dependencies since they're not required at runtime, nor required by folks that are not using TypeScript; doing so means that build environments that prune non-production dependencies (like Heroku) are not able to remove `@types/koa`.

As such, they should be marked as an optional peer dependency which means that they're not required (e.g. npm v7 won't automatically install them), but if they are used in a project then the package manager will ensure the constraint is matched.

This should not be a breaking change because anyone using TypeScript with Koa will need to be installing `@types/koa` anyway; it's possible that this could break builds if people _don't_ have `@types/koa` specified as a direct dependency, but that'd mean they're relying on package managers to hoist the dependency from packages like this one which is bad anyway.

The "fix" for that situation is to add `@types/koa` as a direct dependency.