### PR TITLE
fix: define `render` property on extendable interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -56,7 +56,7 @@ declare namespace views {
 export = views
 
 declare module 'koa' {
-    interface Context {
+    interface ExtendableContext {
         render(viewPath: string, locals?: any): Promise<void>
     }
 }


### PR DESCRIPTION
While augmenting the `Context` does technically work, it's not as effective as targeting `ExtendableContext` as that interface is used more often (specifically because `Context` is not generic, but it's parent `ParameterizedContext` is).

For example, `@koa/router` uses `ParameterizedContext` instead of `Context`, so currently `koa-views` doesn't result in the `render` method being added onto it's context.

This should not be breaking because `Context` is an empty interface that extends `ParameterizedContext` which intersects with `ExtendableContext` so will continue to have the `render` property.